### PR TITLE
Fixed problem with force sources interface as well as integration method selection

### DIFF
--- a/src/MolSim.cpp
+++ b/src/MolSim.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argsv[]) {
         return -1;
     }
 
-    Simulation simulation{inputFilepath, VerletFunctor(), deltaT, endTime};
+    Simulation simulation{inputFilepath, Simulation::IntegrationMethod::VERLET, deltaT, endTime};
 
     simulation.runSimulation();
     return 0;

--- a/src/integration/IntegrationFunctor.h
+++ b/src/integration/IntegrationFunctor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "types/ParticleContainer.h"
@@ -19,5 +20,5 @@ class IntegrationFunctor {
      * @param totalForce
      * @param delta_t
      */
-    virtual void step(ParticleContainer& particle_container, ForceSource& totalForce, double delta_t) = 0;
+    virtual void step(ParticleContainer& particle_container, std::vector<std::unique_ptr<ForceSource>>& force_sources, double delta_t) = 0;
 };

--- a/src/integration/IntegrationFunctor.h
+++ b/src/integration/IntegrationFunctor.h
@@ -14,11 +14,16 @@
 class IntegrationFunctor {
    public:
     /**
+     * @brief Virtual default destructor for the interface
+     */
+    virtual ~IntegrationFunctor() = default;
+
+    /**
      * @brief Performs one step with the respective integration method.
      *
-     * @param particle_container
-     * @param totalForce
-     * @param delta_t
+     * @param particle_container Container of particles on which the integration step is applied
+     * @param force_sources Vector of force sources which are used to calculate the new forces
+     * @param delta_t Time step
      */
     virtual void step(ParticleContainer& particle_container, std::vector<std::unique_ptr<ForceSource>>& force_sources, double delta_t) = 0;
 };

--- a/src/integration/VerletFunctor.h
+++ b/src/integration/VerletFunctor.h
@@ -10,5 +10,12 @@
  */
 class VerletFunctor : public IntegrationFunctor {
    public:
+    /**
+     * @brief Performs one step with the respective integration method.
+     *
+     * @param particle_container Container of particles on which the integration step is applied
+     * @param force_sources Vector of force sources which are used to calculate the new forces
+     * @param delta_t Time step
+     */
     void step(ParticleContainer& particle_container, std::vector<std::unique_ptr<ForceSource>>& force_sources, double delta_t) override;
 };

--- a/src/integration/VerletFunctor.h
+++ b/src/integration/VerletFunctor.h
@@ -3,12 +3,12 @@
 #include "integration/IntegrationFunctor.h"
 
 /**
- * @brief Implementation of the Verlet integration method. Implements the interface IntegrationFunctor.
+ * @brief Implementation of the Strömer-Verlet integration method. Implements the interface IntegrationFunctor.
  *
  * Implements the IntegrationFunctor interface, and therefore updates all particles in the particle_container according to the Verlet
  * integration method.
  */
 class VerletFunctor : public IntegrationFunctor {
    public:
-    void step(ParticleContainer& particle_container, ForceSource& totalForce, double delta_t) override;
+    void step(ParticleContainer& particle_container, std::vector<std::unique_ptr<ForceSource>>& force_sources, double delta_t) override;
 };

--- a/src/physics/ForceSource.h
+++ b/src/physics/ForceSource.h
@@ -28,5 +28,5 @@ class ForceSource {
      *
      * Calculates the force a particle q exerts on another particle p.
      */
-    virtual const std::array<double, 3UL> calculateForce(Particle& p, Particle& q) = 0;
+    virtual std::array<double, 3UL> calculateForce(Particle& p, Particle& q) = 0;
 };

--- a/src/physics/ForceSource.h
+++ b/src/physics/ForceSource.h
@@ -14,6 +14,13 @@
 class ForceSource {
    public:
     /**
+     * @brief Virtual destructor
+     *
+     * Virtual destructor to ensure correct deletion of inheriting classes.
+     */
+    virtual ~ForceSource() = default;
+
+    /**
      * @brief Calculates the force a particle q exerts on another particle p
      * @param p Particle whose force is to be updated
      * @param q Particle which exerts the force on p

--- a/src/physics/GravitationalForce.cpp
+++ b/src/physics/GravitationalForce.cpp
@@ -2,7 +2,7 @@
 
 #include "utils/ArrayUtils.h"
 
-const std::array<double, 3UL> GravitationalForce::calculateForce(Particle& p, Particle& q) {
+std::array<double, 3UL> GravitationalForce::calculateForce(Particle& p, Particle& q) {
     double dist = ArrayUtils::L2Norm(p.getX() - q.getX());
 
     auto f_gravity = (1 / (dist * dist * dist)) * p.getM() * q.getM() * (q.getX() - p.getX());

--- a/src/physics/GravitationalForce.h
+++ b/src/physics/GravitationalForce.h
@@ -18,5 +18,5 @@ class GravitationalForce : public ForceSource {
      *
      * Calculates the gravitational force which q exerts on p
      */
-    const std::array<double, 3UL> calculateForce(Particle& p, Particle& q) override;
+    std::array<double, 3UL> calculateForce(Particle& p, Particle& q) override;
 };

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -17,6 +17,9 @@ Simulation::Simulation(std::string& input_file, IntegrationMethod integration_me
         case IntegrationMethod::VERLET:
             integration_functor = std::make_unique<VerletFunctor>();
             break;
+        default:
+            std::cerr << "Integration method not implemented." << std::endl;
+            exit(1);
     }
 }
 

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "integration/IntegrationFunctor.h"
@@ -16,22 +17,26 @@ class Simulation {
     std::string input_file;
     IOWrapper io_wrapper;
 
-    GravitationalForce gravitational_force;
+    std::vector<std::unique_ptr<ForceSource>> force_sources;
+    std::unique_ptr<IntegrationFunctor> integration_functor;
 
     ParticleContainer particle_container;
-    IntegrationFunctor&& integration_functor;
 
     double delta_t;
     double end_time;
 
    public:
+    enum class IntegrationMethod {
+        VERLET
+    };
+
     /**
      * @brief Construct a new Simulation object
      * @param particle_container
      * @param force_sources
      * @param integration_method
      */
-    Simulation(std::string& input_file, IntegrationFunctor&& integration_functor, double delta_t, double end_time);
+    Simulation(std::string& input_file, IntegrationMethod integration_method, double delta_t, double end_time);
 
     /**
      * @brief Runs the simulation

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -31,19 +31,16 @@ class Simulation {
     };
 
     /**
-     * @brief Construct a new Simulation object
-     * @param particle_container
-     * @param force_sources
-     * @param integration_method
+     * @brief Construct a new Simulation object and initialize all the necessary components
+     * @param input_file Path to the input file
+     * @param integration_method Integration method to use (see 'Simulation::IntegrationMethod')
+     * @param delta_t Time step per iteration
+     * @param end_time End time of the simulation
      */
     Simulation(std::string& input_file, IntegrationMethod integration_method, double delta_t, double end_time);
 
     /**
-     * @brief Runs the simulation
-     * @param particle_container ParticleContainer containing the particles to be simulated
-     * @param force_source ForceSource to be used for the simulation
-     * @param time_step Time step to be used for the simulation
-     * @param iterations Number of iterations to be simulated
+     * @brief Runs the simulation with using the parameters given at construction
      */
     void runSimulation();
 };

--- a/src/types/ParticleContainer.cpp
+++ b/src/types/ParticleContainer.cpp
@@ -10,6 +10,6 @@ void ParticleContainer::addParticle(Particle& p) { particles.push_back(p); }
 
 Particle& ParticleContainer::operator[](int i) { return particles[i]; }
 
-ParticleContainer::Iterator ParticleContainer::begin() { return Iterator(&particles[0]); }
+std::vector<Particle>::iterator ParticleContainer::begin() { return particles.begin(); }
 
-ParticleContainer::Iterator ParticleContainer::end() { return Iterator(&particles[particles.size()]); }
+std::vector<Particle>::iterator ParticleContainer::end() { return particles.end(); }

--- a/src/types/ParticleContainer.h
+++ b/src/types/ParticleContainer.h
@@ -15,38 +15,6 @@ class ParticleContainer {
 
    public:
     /**
-     *  @brief Iterator class for ParticleContainer
-     *
-     * This class implements an iterator for the ParticleContainer class.
-     */
-    struct Iterator {
-        using iterator_category = std::forward_iterator_tag;
-        using difference_type = std::ptrdiff_t;
-        using value_type = Particle;
-        using pointer = Particle*;
-        using reference = Particle&;
-
-        Iterator(pointer ptr) : m_ptr(ptr) {}
-
-        reference operator*() const { return *m_ptr; }
-        pointer operator->() { return m_ptr; }
-        Iterator& operator++() {
-            m_ptr++;
-            return *this;
-        }
-        Iterator operator++(int) {
-            Iterator tmp = *this;
-            ++(*this);
-            return tmp;
-        }
-        friend bool operator==(const Iterator& a, const Iterator& b) { return a.m_ptr == b.m_ptr; };
-        friend bool operator!=(const Iterator& a, const Iterator& b) { return a.m_ptr != b.m_ptr; };
-
-       private:
-        pointer m_ptr;
-    };
-
-    /**
      * @brief Default constructor
      *
      * Generates an empty ParticleContainer object.
@@ -102,7 +70,7 @@ class ParticleContainer {
      *
      * Returns an iterator to the first particle in the container.
      */
-    Iterator begin();
+    std::vector<Particle>::iterator begin();
 
     /**
      * @brief Returns an end iterator for this container
@@ -111,5 +79,5 @@ class ParticleContainer {
      * Returns an iterator to the first memory slot after the last particle in this container.
      * Please note that this iterator is not dereferencable, and should just be used to compare to other iterators.
      */
-    Iterator end();
+    std::vector<Particle>::iterator end();
 };

--- a/src/types/ParticleContainer.h
+++ b/src/types/ParticleContainer.h
@@ -68,7 +68,7 @@ class ParticleContainer {
      * @brief Returns an iterator to the first particle
      * @return Iterator to the first particle
      *
-     * Returns an iterator to the first particle in the container.
+     * Returns the begin iterator for the internal data structure.
      */
     std::vector<Particle>::iterator begin();
 
@@ -76,8 +76,7 @@ class ParticleContainer {
      * @brief Returns an end iterator for this container
      * @return End iterator for this container
      *
-     * Returns an iterator to the first memory slot after the last particle in this container.
-     * Please note that this iterator is not dereferencable, and should just be used to compare to other iterators.
+     * Returns the end iterator for the internal data structure.
      */
     std::vector<Particle>::iterator end();
 };


### PR DESCRIPTION
<!-- markdownlint-disable-next-line -->
### Checklist

<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [x] I tested **all** changes and their related features.
- [x] I updated all relevant documentation (e.g. `README.md`, docstrings, etc.).
- [x] I linked all related open issues to this pull request.

### Description
<!-- Describe your changes in detail. -->

- Fixed the code to now correctly use interfaces (usage of std::unique_ptr)
- The constructor for `Simulation` now receives a value of the internal enum `IntegrationMethod` to select the integration method to be used. The initialization happens inside the constructor
- `IntegrationFunctor.step()` now requires `std::vector<std::unique_ptr<ForceSource>>&` to input instead of a single `ForceSource&&`. Like this the simulation can initialize the list of forces at construction and pass it by reference to the step method.
-  Fixed some mistakes in the documentation comments.
