### PR TITLE
Fix particleContainer reserve size calculation

### DIFF
--- a/src/io/input/CubFileReader.cpp
+++ b/src/io/input/CubFileReader.cpp
@@ -60,7 +60,7 @@ void CubFileReader::readFile(const std::string& filepath, ParticleContainer& par
 
         auto spawner = CuboidSpawner(lower_left_front_corner, grid_dimensions, grid_spacing, mass, initial_velocity, type);
 
-        particleContainer.reserve(particleContainer.size() + nx * ny * nz);
+        particleContainer.reserve(particleContainer.size() + static_cast<long>(nx) * ny * nz);
         spawner.spawnParticles(particleContainer);
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line -->
### Checklist

<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [x] I tested **all** changes and their related features.
- [x] I updated all relevant documentation (e.g. `README.md`, docstrings, etc.).
- [x] I linked all related open issues to this pull request.

### Description
<!-- Describe your changes in detail. -->

- Prevent Overflow in size reservation